### PR TITLE
Fix Steps text color to match body prose

### DIFF
--- a/packages/pure/components/user/Steps.astro
+++ b/packages/pure/components/user/Steps.astro
@@ -76,7 +76,8 @@ const { html } = processSteps(content)
     margin-top: 0;
     transform: translateY(var(--shift-y));
     margin-bottom: var(--shift-y);
-    color: hsl(var(--foreground) / var(--un-text-opacity, 1));
+    /* Inherit the body prose color so step text matches surrounding paragraphs. */
+    color: inherit;
   }
   .sl-steps > li > :first-child:where(h1, h2, h3, h4, h5, h6) {
     --lh: calc(1.2em);


### PR DESCRIPTION
## What

The first child of each `<Steps>` item was forced to `color: hsl(var(--foreground) ...)`, which differs from the typography preset's body color. In dark mode (`prose-invert`) the step text rendered near-white while body paragraphs are muted; the mismatch was visible in light mode too.

## Change

Use `color: inherit` on the step item's first child so step text inherits the body prose color (`li` → `ol.sl-steps` → `.prose`). This matches surrounding paragraphs in both light and dark themes. The step-number bullet still uses `--foreground`.

One-line change in the shared `Steps.astro`, so all posts using `<Steps>` benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)